### PR TITLE
Practice filtering-by-user's Site feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 
 # Ignore the seed data
 /db/seeds.rb
+
+roy_notes.txt

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -25,6 +25,7 @@ class PartnersController < ApplicationController
   def show
     @partner = Partner.find(params[:id])
     @event = Event.new
+    # If this partner is from GHRI, set a var that the view can use to show every damn practice.
     if @partner.site.id == 0 then
       @selected_partner_id = 0
     else

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -104,7 +104,7 @@ class PracticesController < ApplicationController
         :prac_aco_join_medicaid, :interest_why, :interest_expect,
         :interest_challenge, :recruitment_source, :recruitment_source_referral,
         :prac_ehr_mu_yr, :interest_yn, :interest_why_not, :interest_why_not_other,
-        :interest_contact_month, :prac_state, :prac_own_clinician,
+        :interest_contact_month, :prac_state, :site_id, :prac_own_clinician,
         :prac_own_hosp, :prac_own_hmo, :prac_own_fqhc, :prac_own_nonfed, :prac_own_academic,
         :prac_own_fed, :prac_own_rural, :prac_own_ihs, :prac_own_other,
         :prac_aco_medicaid, :prac_aco_medicare, :prac_aco_commercial,

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -7,6 +7,8 @@ class Practice < ActiveRecord::Base
 	has_and_belongs_to_many :partners
 	has_one :practice_survey
 
+	belongs_to :site
+
 	has_many :personnels, dependent: :destroy
 	accepts_nested_attributes_for :personnels, :reject_if => :all_blank,
 		:allow_destroy => true

--- a/app/policies/practice_policy.rb
+++ b/app/policies/practice_policy.rb
@@ -4,8 +4,9 @@ class PracticePolicy < ApplicationPolicy
 			if user.admin?
 				scope.all
 			else
-				scope.all
+				# scope.all
 				# scope.joins(:partners).where('partners.site_id' => user.site_id)
+				scope.where('site_id' => user.site_id)
 			end
 		end
 	end

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -20,6 +20,7 @@
   <%= link_to image_tag("plus-arrow-blue.png", size: "30x15", alt: "Add New Practice"), new_practice_path, class: 'addButton', title: 'Add New Practice', rel: 'tooltip' %>
 
   <span class='clearfix'>&nbsp;</span>
+  <!-- if this partner is from GHRI, show every practice. -->
   <% if @selected_partner_id == 0 %>
     <%= render 'practice_snapshot_all' %>
   <% else %>

--- a/app/views/practices/_form.html.erb
+++ b/app/views/practices/_form.html.erb
@@ -63,6 +63,8 @@
         <td><%= f.text_field :city, size: 40 %></td>
         <td><%= f.label :prac_state, "State" %></td>
         <td><%= f.select :prac_state, Practice::PRAC_STATE_VALS, include_blank: true %></td>
+        <td><%= f.label :site_id, "Site" %></td>
+        <td><%= f.select :site_id, Site::SITE_VALS, include_blank: true %></td>
       </tr>
       <tr>
         <td><%= f.label :zip_code, "ZIP Code" %></td>

--- a/db/migrate/20151021170556_add_site_id_to_practices.rb
+++ b/db/migrate/20151021170556_add_site_id_to_practices.rb
@@ -1,0 +1,13 @@
+# https://stackoverflow.com/questions/17226902/custom-helper-methods-for-rails-3-2-migrations
+require File.expand_path('lib/cache_helper')
+include CacheHelper
+
+class AddSiteIdToPractices < ActiveRecord::Migration
+  def up
+    add_reference :practices, :site, index: true, foreign_key: true
+    CacheHelper.set_practice_sites
+  end
+  def down
+    remove_reference :practices, :site
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151019225144) do
+ActiveRecord::Schema.define(version: 20151021170556) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -158,6 +158,7 @@ ActiveRecord::Schema.define(version: 20151019225144) do
   create_table "partners", force: :cascade do |t|
     t.integer  "site_id",                             null: false
     t.string   "name",                                null: false
+    t.integer  "role",                   default: 0,  null: false
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.string   "email",                  default: "", null: false
@@ -173,7 +174,6 @@ ActiveRecord::Schema.define(version: 20151019225144) do
     t.integer  "failed_attempts",        default: 0,  null: false
     t.string   "unlock_token"
     t.datetime "locked_at"
-    t.integer  "role"
     t.boolean  "recruiter"
     t.boolean  "coach"
   end
@@ -435,7 +435,10 @@ ActiveRecord::Schema.define(version: 20151019225144) do
     t.string   "pal_status_cached"
     t.string   "study_id",                          limit: 5
     t.boolean  "residency_training_site",                      default: false
+    t.integer  "site_id"
   end
+
+  add_index "practices", ["site_id"], name: "index_practices_on_site_id", using: :btree
 
   create_table "sites", force: :cascade do |t|
     t.string   "name",       null: false
@@ -459,4 +462,5 @@ ActiveRecord::Schema.define(version: 20151019225144) do
   add_foreign_key "partners", "sites"
   add_foreign_key "personnels", "practices"
   add_foreign_key "practice_surveys", "practices"
+  add_foreign_key "practices", "sites"
 end

--- a/lib/cache_helper.rb
+++ b/lib/cache_helper.rb
@@ -15,4 +15,21 @@ module CacheHelper
     end
     "Finished.  Reset #{counter} cache fields on practice records total."
   end
+  def set_practice_sites
+    oregon = Practice::PRAC_STATE_VALS['OR']
+    orprn = Site.find_by_name('ORPRN').id
+    qualis = Site.find_by_name('Qualis').id
+    counter = 0
+    Practice.all.each do |p|
+      if p.prac_state == oregon
+        p.site_id = orprn
+      else
+        p.site_id = qualis
+      end
+      p.save!
+      counter += 1
+      puts("Set site_id on #{counter} practice records") if counter % 10 == 0
+    end
+    puts("Finished.  Set site_id on #{counter} practice records total.")
+  end
 end


### PR DESCRIPTION
This adds a Site field/association to Practices, and sets each existing practice's site based on its State.  This also tweaks the pundit policy for practices so that non-GHRI users will only see practices associated with their site.  Finally, we make Site editable on the /sites/:id/edit view, for the few cases where it's not really based on state.